### PR TITLE
Redux

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "cSpell.words": [
+    "Dynamix",
+    "Synergistics"
+  ]
+}

--- a/App.js
+++ b/App.js
@@ -1,23 +1,18 @@
 import React from 'react';
-// import { StyleSheet } from 'react-native';
 import { Root } from 'native-base';
+// Root: gives us actionSheets to be able to be called from anywhere
 
+import Store from './src/store';
 import Navigator from './src/routes';
 
 export default class App extends React.Component {
   render() {
     return (
-      // <Root style={styles.container}>
-      <Root>
-        <Navigator />
-      </Root>
+      <Store>
+        <Root>
+          <Navigator />
+        </Root>
+      </Store>
     );
   }
 }
-
-// const styles = StyleSheet.create({
-//   container: {
-//     flex: 1,
-//     backgroundColor: '#fff'
-//   }
-// });

--- a/package.json
+++ b/package.json
@@ -18,12 +18,16 @@
     "@expo/vector-icons": "^6.2.2",
     "babel-eslint": "^8.2.1",
     "expo": "^25.0.0",
+    "moment": "^2.20.1",
     "native-base": "^2.3.7",
     "prop-types": "^15.6.0",
     "react": "16.2.0",
     "react-native": "0.52.0",
     "react-native-modal": "^5.0.0",
-    "react-navigation": "^1.0.0-beta.27"
+    "react-navigation": "^1.0.0-beta.27",
+    "redux-logger": "^3.0.6",
+    "redux-thunk": "^2.2.0",
+    "uuid": "^3.2.1"
   },
   "devDependencies": {
     "eslint": "^4.16.0",

--- a/src/data/index.json
+++ b/src/data/index.json
@@ -1,0 +1,47 @@
+{
+  "plan": {
+    "name": "p90x3 - phase 1",
+    "activities": [
+      "Total Synergistics",
+      "Agility X",
+      "Yoga X",
+      "The Challenge",
+      "CVX",
+      "The Warrior",
+      "Rest or Dynamix"
+    ],
+    "repeatCount": 4,
+    "daySkipLimit": 2
+  },
+  "stats": {
+    "totalActivities": "28",
+    "startDate": "1516424400000",
+    "totalDays": 15,
+    "longestStreak": 7,
+    "currentStreak": 3,
+    "daysSkipped": 4,
+    "timesFailed": 2,
+    "activityStats": {
+      "Total Synergistics": {
+        "timesSucceeded": 5,
+        "timesSkipped": 2,
+        "timesFailed": 1
+      },
+      "Yoga X": {
+        "timesSucceeded": 4,
+        "timesSkipped": 3,
+        "timesFailed": 0
+      }
+    }
+  },
+  "logs": [
+    {
+      "timestamp": 1517539570991,
+      "wasCompleted": true
+    },
+    {
+      "timestamp": 1516424400000,
+      "wasCompleted": false
+    }
+  ]
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -2,15 +2,19 @@ import { TabNavigator } from 'react-navigation';
 
 // import RNDefault from './screens/react-native-default';
 import CheckIn from './screens/check-in';
+import Logs from './screens/logs';
+import Plan from './screens/plan';
 
 const Navigator = TabNavigator(
   {
-    // rnDefault: {
-    //   screen: RNDefault
-    // },
-    // ...checkInRoutes
     checkIn: {
       screen: CheckIn
+    },
+    logs: {
+      screen: Logs
+    },
+    plan: {
+      screen: Plan
     }
   },
   {

--- a/src/screens/check-in/index.js
+++ b/src/screens/check-in/index.js
@@ -2,11 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { View, Text } from 'react-native';
 import { Container, Content, Footer, Button } from 'native-base';
-// import Modal from 'react-native-modal';
 
-// import PrettyPrint from '../components/pretty-print';
-// import Success from './success';
-// import Fail from './fail';
 import Modal from './modal';
 
 class DidYou extends React.Component {
@@ -31,8 +27,6 @@ class DidYou extends React.Component {
   };
 
   render() {
-    // const { navigate } = this.props.navigation;
-
     return (
       <Container>
         {/* <PrettyPrint {...this.props} /> */}

--- a/src/screens/logs.js
+++ b/src/screens/logs.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { View, Text } from 'react-native';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
 import PrettyPrint from '../components/pretty-print';
 
@@ -28,4 +29,8 @@ const styles = {
   }
 };
 
-export default Logs;
+const mapStateToProps = ({ logs }) => {
+  return { logs };
+};
+
+export default connect(mapStateToProps)(Logs);

--- a/src/screens/logs.js
+++ b/src/screens/logs.js
@@ -1,0 +1,31 @@
+import React, { Component } from 'react';
+import { View, Text } from 'react-native';
+import PropTypes from 'prop-types';
+
+import PrettyPrint from '../components/pretty-print';
+
+class Logs extends Component {
+  static displayName = 'Logs';
+
+  static propTypes = {
+    name: PropTypes.string
+  };
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text>Logs</Text>
+
+        <PrettyPrint {...this.props} />
+      </View>
+    );
+  }
+}
+
+const styles = {
+  container: {
+    marginTop: 20
+  }
+};
+
+export default Logs;

--- a/src/screens/plan.js
+++ b/src/screens/plan.js
@@ -1,0 +1,31 @@
+import React, { Component } from 'react';
+import { View, Text } from 'react-native';
+import PropTypes from 'prop-types';
+
+import PrettyPrint from '../components/pretty-print';
+
+class Plan extends Component {
+  static displayName = 'Plan';
+
+  static propTypes = {
+    name: PropTypes.string
+  };
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text>Plan</Text>
+
+        <PrettyPrint {...this.props} />
+      </View>
+    );
+  }
+}
+
+const styles = {
+  container: {
+    marginTop: 20
+  }
+};
+
+export default Plan;

--- a/src/screens/plan.js
+++ b/src/screens/plan.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { View, Text } from 'react-native';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
 import PrettyPrint from '../components/pretty-print';
 
@@ -28,4 +29,8 @@ const styles = {
   }
 };
 
-export default Plan;
+const mapStateToProps = ({ plan }) => {
+  return { ...plan };
+};
+
+export default connect(mapStateToProps)(Plan);

--- a/src/services/id.js
+++ b/src/services/id.js
@@ -1,0 +1,5 @@
+import uuid from 'uuid/v4';
+
+export function generateId() {
+  return uuid();
+}

--- a/src/store/config.js
+++ b/src/store/config.js
@@ -1,0 +1,18 @@
+import { createStore, applyMiddleware, combineReducers, compose } from 'redux';
+import thunkMiddleware from 'redux-thunk';
+import { createLogger } from 'redux-logger';
+
+import reducers from './reducers';
+
+// creates the logger only for dev
+const loggerMiddleware = createLogger({
+  predicate: () => __DEV__
+});
+
+export default function configureStore(initialState) {
+  const enhancers = compose(applyMiddleware(thunkMiddleware, loggerMiddleware));
+
+  const reducer = combineReducers(reducers);
+
+  return createStore(reducer, initialState, enhancers);
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,33 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
-import { createStore, applyMiddleware, combineReducers, compose } from 'redux';
-import thunkMiddleware from 'redux-thunk';
-import { createLogger } from 'redux-logger';
 
-import reducers from './reducers';
+import configureStore from './config';
 
 export default function Store(props) {
-  return <Provider store={store}>{props.children}</Provider>;
+  return <Provider store={configureStore({})}>{props.children}</Provider>;
 }
 
 Store.propTypes = {
   children: PropTypes.node
 };
-
-// ------- config -------
-
-// creates the logger only for dev
-const loggerMiddleware = createLogger({
-  predicate: () => __DEV__
-});
-
-function configureStore(initialState) {
-  const enhancers = compose(applyMiddleware(thunkMiddleware, loggerMiddleware));
-
-  const reducer = combineReducers(reducers);
-
-  return createStore(reducer, initialState, enhancers);
-}
-
-const store = configureStore({});

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Provider } from 'react-redux';
+import { createStore, applyMiddleware, combineReducers, compose } from 'redux';
+import thunkMiddleware from 'redux-thunk';
+import { createLogger } from 'redux-logger';
+
+import reducers from './reducers';
+
+export default function Store(props) {
+  return <Provider store={store}>{props.children}</Provider>;
+}
+
+Store.propTypes = {
+  children: PropTypes.node
+};
+
+// ------- config -------
+
+// creates the logger only for dev
+const loggerMiddleware = createLogger({
+  predicate: () => __DEV__
+});
+
+function configureStore(initialState) {
+  const enhancers = compose(applyMiddleware(thunkMiddleware, loggerMiddleware));
+
+  const reducer = combineReducers(reducers);
+
+  return createStore(reducer, initialState, enhancers);
+}
+
+const store = configureStore({});

--- a/src/store/logs.js
+++ b/src/store/logs.js
@@ -19,7 +19,7 @@ const INITIAL_STATE = {
   'cf69dc28-1b02-4692-9eae-418e5e29820e': {
     id: 'cf69dc28-1b02-4692-9eae-418e5e29820e',
     timestamp: 1517539570991,
-    activity: 'Total Synergistics',
+    activityId: '7dd0ebe5-a8f9-4849-8daf-d5ae0312927d',
     wasCompleted: true
   }
 };

--- a/src/store/logs.js
+++ b/src/store/logs.js
@@ -1,0 +1,34 @@
+import { generateId } from '../services/id';
+import moment from 'moment';
+
+export const actionTypes = { ADD_LOG: 'logs.ADD_LOG' };
+
+export function AddLog(activity, wasCompleted) {
+  return {
+    type: actionTypes.ADD_LOG,
+    payload: {
+      id: generateId(),
+      timestamp: moment().valueOf(),
+      activity,
+      wasCompleted
+    }
+  };
+}
+
+const INITIAL_STATE = {
+  'cf69dc28-1b02-4692-9eae-418e5e29820e': {
+    id: 'cf69dc28-1b02-4692-9eae-418e5e29820e',
+    timestamp: 1517539570991,
+    activity: 'Total Synergistics',
+    wasCompleted: true
+  }
+};
+
+export default function reducer(state = INITIAL_STATE, { type, payload } = {}) {
+  switch (type) {
+    case actionTypes.ADD_LOG:
+      return { ...state, [payload.id]: payload };
+    default:
+      return state;
+  }
+}

--- a/src/store/plan.js
+++ b/src/store/plan.js
@@ -1,0 +1,23 @@
+export const actionTypes = {};
+
+const INITIAL_STATE = {
+  name: 'p90x3 - phase 1',
+  activities: [
+    { id: '7dd0ebe5-a8f9-4849-8daf-d5ae0312927d', name: 'Total Synergistics' },
+    { id: '9a93a330-9190-4b95-a49a-0b9329e4f49a', name: 'Agility X' },
+    { id: '8f7665b0-4c4a-4999-b4b1-28b675ca4d75', name: 'Yoga X' },
+    { id: '8580ecb1-2c76-4e46-bc93-3074e13fa451', name: 'The Challenge' },
+    { id: '13fb2917-c55b-4b70-bfc2-03cfc8ec29ba', name: 'CVX' },
+    { id: '99c8d7c0-389b-4ffa-9cbf-7d288fbb882f', name: 'The Warrior' },
+    { id: '6e390dfc-6cc2-49bb-abf9-88cd30799b14', name: 'Rest or Dynamix' }
+  ],
+  repeatCount: 4,
+  daySkipLimit: 2
+};
+
+export default function reducer(state = INITIAL_STATE, action = {}) {
+  switch (action.type) {
+    default:
+      return state;
+  }
+}

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -1,0 +1,3 @@
+import logs from './logs';
+
+export default { logs };

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -1,3 +1,4 @@
 import logs from './logs';
+import plan from './plan';
 
-export default { logs };
+export default { logs, plan };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1874,6 +1874,10 @@ deep-diff@0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.4.tgz#aac5c39952236abe5f037a2349060ba01b00ae48"
 
+deep-diff@^0.3.5:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
+
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
@@ -4401,7 +4405,7 @@ mkpath@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/mkpath/-/mkpath-0.1.0.tgz#7554a6f8d871834cc97b5462b122c4c124d6de91"
 
-moment@2.x.x, moment@^2.10.6:
+moment@2.x.x, moment@^2.10.6, moment@^2.20.1:
   version "2.20.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
 
@@ -5501,6 +5505,16 @@ redux-logger@^2.7.4:
   dependencies:
     deep-diff "0.3.4"
 
+redux-logger@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
+  dependencies:
+    deep-diff "^0.3.5"
+
+redux-thunk@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
+
 redux@^3.6.0:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
@@ -6593,7 +6607,7 @@ uuid@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
+uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 


### PR DESCRIPTION
## Things
- Wires up redux store similar to phoenix-webview
- add redux logger
  - b/c we can't as easily use redux-devtools here
- Brings in UUID
  - to be able to genearate IDs
  - mostly used for log creation
- Brings in moment
  - Logs will need this
  - Stats logic will need this for date logic
- `data/index.json`
  - dummy data model
  - starting point to show what kind of data we'd like stored
  - not the last say on this
- added tabs for Logs + Plan pages
  - both are skeletons that PrettyPrint